### PR TITLE
Limit de $q_orders results

### DIFF
--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -247,7 +247,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
         FROM '._DB_PREFIX_.'orders o
         LEFT JOIN '._DB_PREFIX_.'order_detail od ON (od.id_order = o.id_order)
         WHERE o.valid = 1
-        AND od.product_id IN ('.implode(',', $productIds).') ORDER BY RAND() LIMIT '.(int)Configuration::get('CROSSSELLING_NBR')*4;
+        AND od.product_id IN ('.implode(',', $productIds).') ORDER BY RAND() LIMIT ' . (int) Configuration::get('CROSSSELLING_NBR')*4;
 
         $orders = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($q_orders);
 

--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -247,7 +247,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
         FROM '._DB_PREFIX_.'orders o
         LEFT JOIN '._DB_PREFIX_.'order_detail od ON (od.id_order = o.id_order)
         WHERE o.valid = 1
-        AND od.product_id IN ('.implode(',', $productIds).')';
+        AND od.product_id IN ('.implode(',', $productIds).') ORDER BY RAND() LIMIT '.(int)Configuration::get('CROSSSELLING_NBR')*4;
 
         $orders = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($q_orders);
 


### PR DESCRIPTION
We limit this query to avoid having an IN query with thousands of unnecessary order ids.

I have multiplied the limit by 4 to minimize the case where products have been disabled.

But having hundreds of IDs in the order ID list or thousands or even hundred of thousands ID in this list (for big shops) make the whole difference between a query that runs a few ms and a query that runs for seconds.

Fixes PrestaShop/PrestaShop#20874