### PR TITLE
Cross selling products not displayed on displayShoppingCartFooter hook

### DIFF
--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -194,7 +194,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
 
     private function getProductIds($hookName, array $configuration)
     {
-        if ('displayShoppingCart' === $hookName) {
+        if ('displayShoppingCart' === $hookName || 'displayShoppingCartFooter' === $hookName) {
             $productIds = array_map(function ($elem) {
                 return $elem['id_product'];
             }, $configuration['cart']->getProducts());


### PR DESCRIPTION
#### Describe the bug

Cross selling products not displayed  on cart page if you hook the module to displayShoppingCartFooter

#### Expected behavior

When you hook the module ps_crossselling on displayShoppingCartFooter, cross selling products must be displayed on the cart footer

#### Steps to Reproduce

Steps to reproduce the behavior:

1. Install the module ps_crossselling
2. Transplant the module to the hook "displayShoppingCartFooter"
3. Add a product to your cart (product already buy with others products)
4. See error (no cross selling products are displayed)

#### Additional information

* PrestaShop version: 1.7.6.3
* PHP version: 7.2
