### PR TITLE
Cache should be customer dependant

### DIFF
--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -344,4 +344,13 @@ class Ps_Crossselling extends Module implements WidgetInterface
 
         return false;
     }
+
+    protected function getCacheId($name = null)
+    {
+        $cacheId = parent::getCacheId($name);
+        if(!empty($this->context->customer->id)){
+            $cacheId .= '|' . (int) $this->context->customer->id;
+        }
+        return $cacheId;
+    }    
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There are several issues in native modules because module cache is not customer dependant.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes #17111
| How to test?  | Add a customer dependent product price, load home page. Authenticate to another user of the same group : the price should be different.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
