### PR TITLE
Fix, direct call of the widget in smarty not works

### DIFF
--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -195,7 +195,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
         if ('displayShoppingCart' === $hookName || 'displayShoppingCartFooter' === $hookName) {
             $productIds = array_map(function ($elem) {
                 return $elem['id_product'];
-            }, $configuration['cart']->getProducts());
+            }, Context::getContext()->cart->getProducts());
         } else {
             $productIds = [$configuration['product']['id_product']];
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | fix using {widget name='ps_crossselling' hook='displayShoppingCart'} not work  with ps_crossselling v2.0.1 Prestashop 1.7.6.8
| Type?         | improvement
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | -
| How to test?  | read below.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


Fix, If you call widget with tag in smarty, eg:
```
in [theme]/templates/checkout/cart.tpl
{widget name='ps_crossselling' hook='displayShoppingCart'}
```
