### PR TITLE
Filter results by product visibility

### DIFF
--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -302,6 +302,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
                 AND od.product_id NOT IN (' . $list_product_ids . ')
                 AND i.cover = 1
                 AND product_shop.active = 1
+                AND product_shop.visibility IN ("both", "catalog", "search")
                 ' . $sql_groups_where . '
                 ORDER BY RAND()
                 LIMIT ' . (int) Configuration::get('CROSSSELLING_NBR')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The crossselling module will display any product found on orders made by the customer, this includes product that have a visibility of Nowhere.  Products configured as Nowhere should not be displayed on the front end.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? |no
| Fixed ticket? | No
| How to test?  | 1. Create order with a product.<br>2. Update this product with visibility nowhere.<br>3. Make an order with a different product.<br>4. Check crossselling block no longer shows the product ordered in the first order.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
