### PR TITLE
Cache management

### DIFF
--- a/upgrade/upgrade_module_2_1_0.php
+++ b/upgrade/upgrade_module_2_1_0.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+function upgrade_module_2_1_0($module)
+{
+    // Clear cache on product change
+    $module->registerHook('actionObjectProductUpdateAfter');
+    $module->registerHook('actionObjectProductDeleteAfter');
+
+    // Avoid break payment flow on cache clearing
+    $module->unregisterHook('actionOrderStatusPostUpdate');
+
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As described in https://github.com/PrestaShop/PrestaShop/issues/24338#issuecomment-1192570046: only cache if there is only one product (avoid exponential number of files). Empty cache on product modification or deletion, but not on order change (avoid interference with payment). Add a button in BO to clear the cache.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/24338.
| How to test?  | Please indicate how to best verify that this PR is correct.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

There are issues that should be discussed:
- When exactly are the actionObjectProduct* hooks called? They must not be called often, otherwise the cache would be ineffective.
- Should we really clean the cache on actionObjectProduct* hooks? If a product changes, it is not possible to determine which templates are affected. If we have 1000 products, and on each product page there are 8 cross-selling products, on average, every product appears in the detail of 8 other products. If we update one product, on average less than 1% of all templates are affected, but it is not possible to determine which ones. In addition, not all product updates will affect the templates, only changes of title, image and prices.
- It could be better to define a cache lifetime, and clear the cache every lifetime interval (e.g. once every day or once every two hours). The cache would be very efficient, and still there will be a very low chance to get invalid products (deleted, invisible or with important changes) showing up.