### PR TITLE
Cache management with lifetime

### DIFF
--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -152,7 +152,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
                         'type' => 'text',
                         'label' => $this->trans('Cache life time', [], 'Modules.Crossselling.Admin'),
                         'name' => 'CROSSSELLING_CACHE_LIFE',
-                        'class' => 'fixed-width-xs',
+                        'class' => 'fixed-width-sm',
                         'desc' => $this->trans('Indicate the time in seconds.', [], 'Modules.Crossselling.Admin'),
                         'hint' => $this->trans('The cache will be cleared at this interval. If left empty or less than a minute, the cache is disabled.', [], 'Modules.Crossselling.Admin'),
                     ],

--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -39,6 +39,8 @@ class Ps_Crossselling extends Module implements WidgetInterface
     const LIMIT_FACTOR = 50;
     private $templateFile;
 
+    private $cache_life;
+
     public function __construct()
     {
         $this->name = 'ps_crossselling';
@@ -59,6 +61,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
         $this->description = $this->trans('Offer your customers the possibility to buy matching items when on a product page.', [], 'Modules.Crossselling.Admin');
 
         $this->templateFile = 'module:ps_crossselling/views/templates/hook/ps_crossselling.tpl';
+        $this->cache_life = (int) Configuration::get('CROSSSELLING_CACHE_LIFE');
     }
 
     public function install()
@@ -110,7 +113,9 @@ class Ps_Crossselling extends Module implements WidgetInterface
 
     protected function clearCache()
     {
-        Configuration::updateValue('CROSSSELLING_CACHE_TS', time());
+        if ($this->cache_life >= 60) {
+            Configuration::updateValue('CROSSSELLING_CACHE_TS', time());
+        }
         parent::_clearCache($this->templateFile);
     }
 
@@ -257,8 +262,7 @@ class Ps_Crossselling extends Module implements WidgetInterface
             return false;
         }
 
-        $cache_life = (int) Configuration::get('CROSSSELLING_CACHE_LIFE');
-        if ($cache_life < 60 || time() > (int) Configuration::get('CROSSSELLING_CACHE_TS') + $cache_life) {
+        if ($this->cache_life < 60 || time() > (int) Configuration::get('CROSSSELLING_CACHE_TS') + $this->cache_life) {
             $this->clearCache();
         }
 

--- a/upgrade/upgrade_module_2_1_0.php
+++ b/upgrade/upgrade_module_2_1_0.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+function upgrade_module_2_1_0($module)
+{
+    $module->unregisterHook('actionOrderStatusPostUpdate');
+    Configuration::updateValue('CROSSSELLING_CACHE_LIFE', 86400);
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Cache only if there is only one product (avoid exponential number of files). Do not empty cache on order change (avoid interference with payment). Add a button in BO to clear the cache. Use a configurable cache life time.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/24338.
| How to test?  | Configure the setting in the BO. Look at the generated cache files in the filesystem at `/var/cache/dev/smarty/cache/ps_crossselling`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

As discussed here https://github.com/PrestaShop/ps_crossselling/pull/42, cache lifetime seems to be a better option to clear the cache than product object hooks. IMO this PR should replace the previous. I'm waiting for feedback.
