### PR TITLE
Assemble products in bulk to save performance

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -70,14 +70,14 @@ jobs:
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -321,14 +321,20 @@ class Ps_Crossselling extends Module implements WidgetInterface
             // Now, we can present the products for the template.
             $productsForTemplate = [];
 
+            // Prepare a standardized array with products
+            $rawProducts = [];
+            foreach ($order_products as $orderProduct) {
+                $rawProducts[] = ['id_product' => $orderProduct['product_id']];
+            }
+
             // Assemble & present in bulk or separately, depending on core version
             $presentationSettings->showPrices = $showPrice;
             $assembleInBulk = method_exists($assembler, 'assembleProducts');
             if ($assembleInBulk) {
-                $order_products = $assembler->assembleProducts($order_products);
+                $rawProducts = $assembler->assembleProducts($rawProducts);
             }
-            if (is_array($order_products)) {
-                foreach ($order_products as $rawProduct) {
+            if (is_array(rawProducts)) {
+                foreach (rawProducts as $rawProduct) {
                     $productsForTemplate[] = $presenter->present(
                         $presentationSettings,
                         ($assembleInBulk ? $rawProduct : $assembler->assembleProduct($rawProduct)),

--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -333,8 +333,8 @@ class Ps_Crossselling extends Module implements WidgetInterface
             if ($assembleInBulk) {
                 $rawProducts = $assembler->assembleProducts($rawProducts);
             }
-            if (is_array(rawProducts)) {
-                foreach (rawProducts as $rawProduct) {
+            if (is_array($rawProducts)) {
+                foreach ($rawProducts as $rawProduct) {
                     $productsForTemplate[] = $presenter->present(
                         $presentationSettings,
                         ($assembleInBulk ? $rawProduct : $assembler->assembleProduct($rawProduct)),

--- a/ps_crossselling.php
+++ b/ps_crossselling.php
@@ -318,15 +318,20 @@ class Ps_Crossselling extends Module implements WidgetInterface
                 );
             }
 
+            // Now, we can present the products for the template.
             $productsForTemplate = [];
 
+            // Assemble & present in bulk or separately, depending on core version
             $presentationSettings->showPrices = $showPrice;
-
+            $assembleInBulk = method_exists($assembler, 'assembleProducts');
+            if ($assembleInBulk) {
+                $order_products = $assembler->assembleProducts($order_products);
+            }
             if (is_array($order_products)) {
-                foreach ($order_products as $productId) {
+                foreach ($order_products as $rawProduct) {
                     $productsForTemplate[] = $presenter->present(
                         $presentationSettings,
-                        $assembler->assembleProduct(['id_product' => $productId['product_id']]),
+                        ($assembleInBulk ? $rawProduct : $assembler->assembleProduct($rawProduct)),
                         $this->context->language
                     );
                 }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Uses `assembleProducts` method added in 9.0 (https://github.com/PrestaShop/PrestaShop/pull/37399) for getting product data if it exists. This makes it load the data in just one query instead of n products.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Test that the module works correctly

### Related simmilar PRs:
https://github.com/PrestaShop/ps_newproducts/pull/29
https://github.com/PrestaShop/ps_specials/pull/19
https://github.com/PrestaShop/ps_bestsellers/pull/36
https://github.com/PrestaShop/ps_categoryproducts/pull/42
https://github.com/PrestaShop/ps_crossselling/pull/47
https://github.com/PrestaShop/ps_featuredproducts/pull/59
https://github.com/PrestaShop/ps_viewedproduct/pull/38